### PR TITLE
Made bears compatible with Numpy v1.20+ and v2.0+ for vLLM

### DIFF
--- a/src/bears/core/frame/DatumScalableSeries.py
+++ b/src/bears/core/frame/DatumScalableSeries.py
@@ -18,6 +18,7 @@ from bears.util import (
     is_null,
     optional_dependency,
 )
+from bears.util.language._import import np_str
 
 DatumScalableSeries = "DatumScalableSeries"
 
@@ -223,8 +224,8 @@ class DatumScalableSeries(ScalableSeries):
         if isinstance(dtype, str):
             dtype = np.type(dtype)
         out = self._constructor(dtype.__call__(self._data), dtype=dtype)
-        if np.issubdtype(dtype, np.str_) and self.__str_to_object:
-            ## To get true unicode arrays, pass dtype=np.str_
+        if np.issubdtype(dtype, np_str) and self.__str_to_object:
+            ## To get true unicode arrays, pass dtype=np_str
             out = out.astype(object)
         return out
 

--- a/src/bears/core/frame/NumpyArrayScalableSeries.py
+++ b/src/bears/core/frame/NumpyArrayScalableSeries.py
@@ -20,6 +20,7 @@ from bears.util import (
     is_null,
     wrap_fn_output,
 )
+from bears.util.language._import import np_number, np_str
 
 NumpyArrayScalableSeries = "NumpyArrayScalableSeries"
 
@@ -62,7 +63,7 @@ class NumpyArrayScalableSeries(ScalableSeries):
                     str_to_object=self._str_to_object,
                 )
             assert isinstance(data, np.ndarray), f"Found type: {type(data)}"
-            if np.issubdtype(data.dtype, np.str_) and str_to_object:
+            if np.issubdtype(data.dtype, np_str) and str_to_object:
                 data: np.ndarray = data.astype(object)  ## Do not allow unicode arrays with dtype like "<U8"
             self._data: np.ndarray = data
         self.layout_validator(self._data)
@@ -277,8 +278,8 @@ class NumpyArrayScalableSeries(ScalableSeries):
 
     def astype(self, dtype: Union[np.dtype, str]) -> NumpyArrayScalableSeries:
         out: np.ndarray = self._data.astype(dtype)
-        if dtype in {str, "str"} and np.issubdtype(out.dtype, np.str_):
-            ## To get true unicode arrays, pass dtype=np.str_
+        if dtype in {str, "str"} and np.issubdtype(out.dtype, np_str):
+            ## To get true unicode arrays, pass dtype=np_str
             out = out.astype(object)
         return self._constructor(out)
 
@@ -342,7 +343,7 @@ class NumpyArrayScalableSeries(ScalableSeries):
         else:
             nan_policy = "propagate"
             data: np.ndarray = self._data
-        if np.issubdtype(data.dtype, np.number):
+        if np.issubdtype(data.dtype, np_number):
             vals, counts = np.unique(data, return_counts=True)
             modes, _ = vals[counts.argmax()], counts.max()
             mode: Union[int, float] = modes[()]

--- a/src/bears/util/concurrency/_utils.py
+++ b/src/bears/util/concurrency/_utils.py
@@ -185,7 +185,7 @@ def wait(
     **kwargs,
 ) -> NoReturn:
     """Join operation on a single future or a collection of futures."""
-    progress_bar: Optional[Dict] = Alias.get_progress_bar(kwargs)
+    progress_bar: Optional[Dict] = Alias.get_progress_bar(kwargs, default_progress_bar=False)
 
     if isinstance(futures, (list, tuple, set, np.ndarray)):
         futures: List[Any] = list(futures)
@@ -299,7 +299,7 @@ def accumulate(
         >>> results = accumulate(futures_dict)
         >>> print(results)  ## {'0': 0.0, '1': 1.0, '2': 2.0}
     """
-    progress_bar: Optional[Dict] = Alias.get_progress_bar(kwargs)
+    progress_bar: Optional[Dict] = Alias.get_progress_bar(kwargs, default_progress_bar=False)
     if isinstance(futures, (list, set, tuple)) and len(futures) > 0:
         if isinstance(first_item(futures), Future):
             item_wait: float = get_default(item_wait, _LOCAL_ACCUMULATE_ITEM_WAIT)
@@ -412,7 +412,7 @@ def accumulate_iter(
     Here we iteratively accumulate and yield completed futures as they have completed.
     This might return them out-of-order.
     """
-    progress_bar: Optional[Dict] = Alias.get_progress_bar(kwargs)
+    progress_bar: Optional[Dict] = Alias.get_progress_bar(kwargs, default_progress_bar=False)
     pbar: ProgressBar = ProgressBar.of(
         progress_bar,
         total=len(futures),

--- a/src/bears/util/language/_import.py
+++ b/src/bears/util/language/_import.py
@@ -1,3 +1,4 @@
+import numbers
 import types
 from contextlib import contextmanager
 from typing import List, Literal, Optional, Set, Tuple, Union
@@ -78,6 +79,49 @@ def optional_dependency(
                 msg = f'Missing optional dependency "{missing_module}". Use pip or conda to install.'
                 print(f"Warning: {msg}")
                 __WARNED_OPTIONAL_MODULES.add(missing_module)
+
+
+_IS_NUMPY_INSTALLED: bool = False
+
+np_number = numbers.Real
+np_bool = bool
+np_integer = int
+np_floating = float
+np_str = str
+
+with optional_dependency("numpy"):
+    import numpy as np
+
+    assert isinstance(np.ndarray, type)
+
+    ## Patch for types between Numpy v1.20+ to v2.0+:
+    if hasattr(np, "number"):
+        np_number = np.number  ## In Numpy v1.20+ and Numpy v2.0+
+    if hasattr(np, "integer"):
+        np_integer = np.integer  ## In Numpy v1.20+ and Numpy v2.0+
+    if hasattr(np, "floating"):
+        np_floating = np.floating  ## In Numpy v1.20+ and Numpy v2.0+
+    if hasattr(np, "bool_"):
+        np_bool = np.bool_  ## In Numpy v1.20+ and Numpy v2.0+
+    elif hasattr(np, "bool"):
+        np_bool = np.bool  ## In Numpy v2.0+
+    if hasattr(np, "unicode_"):
+        np_str = np.unicode_  ## In Numpy v1.20+
+    elif hasattr(np, "str_"):
+        np_str = np.str_  ## In Numpy v2.0+
+
+    _IS_NUMPY_INSTALLED: bool = True
+
+
+_IS_PANDAS_INSTALLED: bool = False
+
+with optional_dependency("pandas"):
+    import pandas as pd
+
+    assert isinstance(pd.DataFrame, type)
+    assert isinstance(pd.Series, type)
+
+    _IS_PANDAS_INSTALLED: bool = True
 
 
 _IS_RAY_INSTALLED: bool = False

--- a/src/bears/util/language/_string.py
+++ b/src/bears/util/language/_string.py
@@ -19,7 +19,7 @@ import pandas as pd
 from pydantic import confloat, conint, validate_call
 
 from ._function import is_function
-from ._import import optional_dependency
+from ._import import np_bool, np_floating, np_integer, optional_dependency
 
 StructuredBlob = Union[List, Dict, List[Dict]]  ## used for type hints.
 KERNEL_START_DT: datetime = datetime.now()
@@ -70,11 +70,11 @@ _PUNCTUATION_REMOVAL_TABLE_WITH_LOWERCASE_AND_SPACE_AND_NUMBERS = str.maketrans(
 class NeverFailJsonEncoder(json.JSONEncoder):
     def default(self, obj):
         # print(f'Running NeverFailJsonEncoder')
-        if isinstance(obj, (np.integer, int)):
+        if isinstance(obj, (np_integer, int)):
             return int(obj)
-        elif isinstance(obj, (np.bool, bool)):
+        elif isinstance(obj, (np_bool, bool)):
             return bool(obj)
-        elif isinstance(obj, (np.floating, float)):
+        elif isinstance(obj, (np_floating, float)):
             return float(obj)
         elif isinstance(obj, (np.ndarray, pd.Series, list, set, tuple)):
             return obj.tolist()

--- a/src/bears/util/language/_structs.py
+++ b/src/bears/util/language/_structs.py
@@ -24,7 +24,7 @@ import pandas as pd
 from autoenum import AutoEnum
 
 from ._alias import set_param_from_alias
-from ._import import optional_dependency
+from ._import import np_bool, optional_dependency
 from ._utils import get_default, is_not_null
 
 ListOrTuple = Union[List, Tuple]
@@ -902,7 +902,7 @@ with optional_dependency("torch"):
     import torch
 
     NUMPY_TO_TORCH_DTYPE_MAP = {
-        np.bool: torch.bool,
+        np_bool: torch.bool,
         np.uint8: torch.uint8,
         np.int8: torch.int8,
         np.int16: torch.int16,


### PR DESCRIPTION
*Description of changes:*

Made bears compatible with Numpy v1.20+ and v2.0+ for vLLM 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
